### PR TITLE
docs: enhance content for llms.txt AI consumption and endpoint documentation

### DIFF
--- a/docs/01-overview.mdx
+++ b/docs/01-overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Architecture and purpose of the CDN edge node simulator
+description: Architecture, endpoints, vendor header simulation, and modular design of the NGINX-based CDN edge node simulator deployed on Ubuntu 24.04 in Azure
 sidebar:
   order: 1
 ---
@@ -47,6 +47,72 @@ The NGINX edge node:
 | Cache-Control respect | `proxy_cache_valid` with origin header passthrough |
 | Cache status reporting | `add_header X-Cache-Status $upstream_cache_status` |
 | Health endpoint | `/health` location returning 200 OK |
+
+## Endpoints and Request/Response Behavior
+
+### Health Check
+
+```
+GET /health
+```
+
+Response (200 OK, `Content-Type: application/json`):
+
+```json
+{
+  "status": "healthy",
+  "component": "cdn-edge",
+  "engine": "nginx",
+  "vendor_profiles": ["akamai", "cloudflare", "cloudfront", "fastly", "azure-front-door"]
+}
+```
+
+### CDN Proxy (All Other Paths)
+
+```
+GET /<any-path>
+```
+
+Request headers injected toward origin (67+ headers from 5 vendors):
+
+| Category | Headers Added |
+|---|---|
+| Client IP | `True-Client-IP`, `CF-Connecting-IP`, `Fastly-Client-IP`, `X-Azure-ClientIP`, `CloudFront-Viewer-Address`, `X-Forwarded-For`, `X-Real-IP` |
+| Geolocation | `X-Akamai-Edgescape` (compound), `CF-IPCountry`, `cf-ipcity`, `cf-iplatitude/longitude`, `CloudFront-Viewer-Country/City/Latitude/Longitude`, `X-Geo-Country-Code/City/Region` |
+| Device Detection | `CloudFront-Is-Mobile-Viewer`, `CloudFront-Is-Desktop-Viewer`, `CloudFront-Is-Tablet-Viewer`, `X-Akamai-Device-Characteristics` |
+| TLS/Fingerprint | `CloudFront-Viewer-TLS`, `cf-ja3-hash`, `cf-ja4`, `CloudFront-Viewer-JA3-Fingerprint` |
+| Bot Detection | `cf-bot-score` (85 = likely human), `cf-verified-bot` |
+| Request Tracing | `Cf-Ray`, `X-Akamai-Request-ID`, `X-Amz-Cf-Id`, `X-Azure-Ref` |
+| Edge Identity | `X-CDN-Edge`, `X-CDN-POP`, `X-Served-By`, `Fastly-FF`, `X-Azure-FDID` |
+| Standard | `Via`, `Forwarded`, `CDN-Loop`, `X-Forwarded-Proto/Host/Port` |
+
+Response headers added to every proxied response:
+
+| Header | Values | Purpose |
+|---|---|---|
+| `X-Cache-Status` | `HIT`, `MISS`, `BYPASS`, `EXPIRED`, `STALE` | Cache behavior for this request |
+| `X-CDN-Edge` | `cdn-simulator` | Identifies this edge node |
+| `X-CDN-POP` | `SJC` | Simulated Point of Presence IATA code |
+| `X-Served-By` | `cache-sjc3120-SJC` | Simulated cache node in Fastly format |
+| `X-Request-ID` | UUID (per-request) | Unique request identifier |
+
+### Cache Behavior
+
+- First request to any path: `X-Cache-Status: MISS` (fetched from origin, now cached)
+- Subsequent identical requests: `X-Cache-Status: HIT` (served from disk cache)
+- Cache key: `$scheme$host$request_uri` (scheme + hostname + full path + query string)
+- Cache TTL: 10 minutes for 200/301/302, 1 minute for 404
+- Stale serving: returns cached content on origin errors (500/502/503/504)
+
+### VM Access
+
+| Access Method | Command/Path |
+|---|---|
+| SSH | `ssh azureuser@<PUBLIC_IP>` |
+| NGINX config | `/etc/nginx/conf.d/cdn-edge.conf` |
+| NGINX logs | `/var/log/nginx/access.log` and `/var/log/nginx/error.log` |
+| Cache directory | `/var/cache/nginx/cdn/` |
+| Cloud-init log | `/var/log/cloud-init-output.log` |
 
 ## Modular Component Design
 

--- a/docs/02-prerequisites.mdx
+++ b/docs/02-prerequisites.mdx
@@ -1,6 +1,6 @@
 ---
 title: Prerequisites
-description: Required tools and access for deploying the CDN edge node
+description: Required tools (Azure CLI, Terraform >= 1.5, SSH key pair), Azure subscription permissions, and estimated monthly cost ($39 USD) for deploying the CDN edge node VM
 sidebar:
   order: 2
 ---

--- a/docs/03-deploy.mdx
+++ b/docs/03-deploy.mdx
@@ -1,6 +1,6 @@
 ---
 title: Deploy
-description: Terraform plan for deploying the CDN edge node on Azure
+description: Complete Terraform HCL (main.tf, variables.tf, network.tf, vm.tf, outputs.tf, cloud-init.yaml) for deploying the CDN edge node as an Azure Standard_B2s Ubuntu 24.04 VM with VNet, PIP, NSG, and NGINX caching reverse proxy provisioned via cloud-init
 sidebar:
   order: 3
 ---

--- a/docs/05-verify.mdx
+++ b/docs/05-verify.mdx
@@ -1,11 +1,11 @@
 ---
 title: Verify
-description: Smoke tests and cache validation for the CDN edge node
+description: Smoke test commands with expected HTTP response codes, X-Cache-Status header values (HIT/MISS), health check JSON response, cache directory inspection, origin connectivity checks, and troubleshooting for cloud-init, NGINX startup, and NSG issues
 sidebar:
   order: 5
 ---
 
-After deployment, run these checks to confirm the CDN edge node is functioning correctly.
+After deployment, run these checks to confirm the CDN edge node is functioning correctly. Allow 2-3 minutes after `terraform apply` for cloud-init to finish installing NGINX.
 
 ## Health Check
 
@@ -134,6 +134,55 @@ Expected output:
 HTTP 200 | Cache: MISS
 === Request 2 (expect HIT) ===
 HTTP 200 | Cache: HIT
+```
+
+## Vendor Header Verification
+
+Verify all CDN vendor headers are being injected by requesting the `/headers` path (when using httpbin.org as origin):
+
+```bash
+curl -s "http://<PUBLIC_IP>/headers" | python3 -m json.tool
+```
+
+Expected response includes headers from all five vendors:
+
+```json
+{
+    "headers": {
+        "True-Client-Ip": "<YOUR_CLIENT_IP>",
+        "Cf-Connecting-Ip": "<YOUR_CLIENT_IP>",
+        "Cf-Ipcountry": "US",
+        "Cf-Ray": "<request_id>-SJC",
+        "Cf-Bot-Score": "85",
+        "Cf-Ja3-Hash": "e7d705a3286e19ea42f587b344ee6865",
+        "Cloudfront-Viewer-Country": "US",
+        "Cloudfront-Viewer-City": "San Jose",
+        "Cloudfront-Is-Desktop-Viewer": "true",
+        "Cloudfront-Is-Mobile-Viewer": "false",
+        "Fastly-Client-Ip": "<YOUR_CLIENT_IP>",
+        "X-Akamai-Edgescape": "georegion=263,country_code=US,...",
+        "X-Azure-Clientip": "<YOUR_CLIENT_IP>",
+        "X-Azure-Fdid": "a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1",
+        "X-Geo-Country-Code": "US"
+    }
+}
+```
+
+### Device Detection Test
+
+Test with a mobile User-Agent to verify device detection headers change:
+
+```bash
+curl -s "http://<PUBLIC_IP>/headers?device=mobile" \
+  -H "User-Agent: Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)" \
+  | python3 -m json.tool | grep -E "Is-Mobile|Is-Desktop|is_mobile"
+```
+
+Expected:
+
+```
+"Cloudfront-Is-Desktop-Viewer": "false",
+"Cloudfront-Is-Mobile-Viewer": "true",
 ```
 
 ## Troubleshooting

--- a/docs/06-integrate.mdx
+++ b/docs/06-integrate.mdx
@@ -1,6 +1,6 @@
 ---
 title: Integrate with F5 XC
-description: Connect the CDN edge node to F5 Distributed Cloud as the origin
+description: Configure the CDN edge NGINX proxy_pass to forward to an F5 XC HTTP load balancer VIP as the origin server, set up DNS or hosts file routing, and verify end-to-end request flow including WAF policy enforcement through the CDN layer
 sidebar:
   order: 6
 ---

--- a/docs/07-teardown.mdx
+++ b/docs/07-teardown.mdx
@@ -1,6 +1,6 @@
 ---
 title: Teardown
-description: Destroy the CDN edge node infrastructure and clean up resources
+description: Run terraform destroy to remove all Azure resources (resource group, VM, VNet, PIP, NSG), clean up local Terraform state, and revert DNS or hosts file changes. Monthly cost stops immediately on destroy.
 sidebar:
   order: 7
 ---

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: CDN Simulator
-description: NGINX-based CDN edge node simulator for multi-vendor lab environments
+description: NGINX-based CDN edge node simulator that injects realistic headers from Akamai, Cloudflare, Amazon CloudFront, Fastly, and Azure Front Door. Deploys as an Ubuntu 24.04 Azure VM via Terraform with NGINX caching reverse proxy. Used as a modular lab component in front of F5 Distributed Cloud HTTP load balancers.
 template: splash
 sidebar:
   hidden: true
@@ -19,30 +19,42 @@ hero:
       variant: minimal
 ---
 
-import { CardGrid } from '@astrojs/starlight/components';
-import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
-
 ## What This Provides
 
-<CardGrid>
-  <LinkCard
-    title="Single Edge Node"
-    description="One Ubuntu 24.04 VM running NGINX as a caching reverse proxy — the minimum viable CDN edge."
-    href="01-overview/"
-  />
-  <LinkCard
-    title="Terraform Deployment"
-    description="Complete Azure infrastructure as code: VNet, PIP, NSG, and VM with cloud-init provisioning."
-    href="03-deploy/"
-  />
-  <LinkCard
-    title="Origin Integration"
-    description="Configure the edge to forward cache misses to an F5 XC HTTP load balancer as the origin."
-    href="06-integrate/"
-  />
-  <LinkCard
-    title="Cache Verification"
-    description="Validate HIT/MISS behavior with X-Cache-Status headers and NGINX cache inspection."
-    href="05-verify/"
-  />
-</CardGrid>
+- **[Single Edge Node](01-overview/)** — One Ubuntu 24.04 VM running NGINX as a caching reverse proxy, the minimum viable CDN edge
+- **[Terraform Deployment](03-deploy/)** — Complete Azure infrastructure as code: VNet, PIP, NSG, and VM with cloud-init provisioning
+- **[67+ CDN Vendor Headers](04-nginx-config/)** — Simulates Akamai, Cloudflare, CloudFront, Fastly, and Azure Front Door request headers including True-Client-IP, CF-Connecting-IP, geolocation, device detection, JA3/JA4 fingerprints, and bot scores
+- **[Origin Integration](06-integrate/)** — Configure the edge to forward cache misses to an F5 XC HTTP load balancer as the origin
+- **[Cache Verification](05-verify/)** — Validate HIT/MISS behavior with X-Cache-Status headers and NGINX cache inspection
+
+## Quick Reference
+
+After deployment, the CDN edge node exposes:
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `http://<PUBLIC_IP>/health` | GET | Health check — returns JSON with component status and vendor profiles |
+| `http://<PUBLIC_IP>/` | GET | CDN proxy — caches and forwards requests to the origin server |
+| `http://<PUBLIC_IP>/<any-path>` | GET | CDN proxy — all paths are proxied with caching and vendor headers |
+
+Response headers added to every proxied response:
+
+| Header | Example | Purpose |
+|---|---|---|
+| `X-Cache-Status` | `HIT` or `MISS` | Whether response was served from cache |
+| `X-CDN-Edge` | `cdn-simulator` | Identifies this edge node |
+| `X-CDN-POP` | `SJC` | Simulated Point of Presence code |
+| `X-Served-By` | `cache-sjc3120-SJC` | Simulated cache node identifier |
+| `X-Request-ID` | UUID | Unique per-request identifier |
+
+## Documentation Guide
+
+| Page | Audience | Purpose |
+|---|---|---|
+| [Overview](01-overview/) | Human + AI | Architecture, multi-vendor context, what this simulates |
+| [Prerequisites](02-prerequisites/) | AI | Required tools, Azure subscription, SSH keys, cost estimate |
+| [Deploy](03-deploy/) | AI | Complete Terraform HCL — copy and apply to deploy |
+| [NGINX Configuration](04-nginx-config/) | Human + AI | All 67+ CDN vendor headers with exact values and purposes |
+| [Verify](05-verify/) | AI | Smoke test commands with expected request/response behavior |
+| [Integrate with F5 XC](06-integrate/) | Human + AI | Connect edge to F5 XC as origin, end-to-end verification |
+| [Teardown](07-teardown/) | AI | Destroy all resources, cleanup commands |


### PR DESCRIPTION
## Summary

- Replace JSX `CardGrid`/`LinkCard` components in `docs/index.mdx` with pure markdown so llms.txt endpoints render readable content instead of raw JSX code
- Enrich frontmatter `description` fields across all 7 doc pages with specific details (tool versions, resource lists, endpoint behavior) so AI assistants understand page purpose from metadata alone
- Add quick-reference tables for endpoints, response headers, CDN vendor header categories, cache behavior specs, and verification commands

Closes #8

## Test plan

- [ ] CI checks pass (linked issue check + linting)
- [ ] Verify llms.txt endpoint renders index page as readable markdown (no JSX artifacts)
- [ ] Confirm frontmatter descriptions are surfaced correctly in llms.txt output
- [ ] Verify endpoint reference tables render correctly in both web and plain-text views

🤖 Generated with [Claude Code](https://claude.com/claude-code)