### PR TITLE
docs: sync deploy documentation with production-optimized configuration

### DIFF
--- a/docs/02-prerequisites.mdx
+++ b/docs/02-prerequisites.mdx
@@ -1,6 +1,6 @@
 ---
 title: Prerequisites
-description: Required tools (Azure CLI, Terraform >= 1.5, SSH key pair), Azure subscription permissions, and estimated monthly cost ($39 USD) for deploying the CDN edge node VM
+description: Required tools (Azure CLI, Terraform >= 1.5, SSH key pair), Azure subscription permissions, and estimated monthly cost (~$140 USD for Standard_D4s_v5) for deploying the performance-optimized CDN edge node VM
 sidebar:
   order: 2
 ---
@@ -72,11 +72,11 @@ The URL of the F5 XC HTTP load balancer that this edge node will forward traffic
 
 | Resource | SKU | Estimated Monthly Cost |
 |---|---|---|
-| Ubuntu 24.04 VM | Standard_B2s (2 vCPU, 4 GiB) | ~$30 USD |
+| Ubuntu 24.04 VM | Standard_D4s_v5 (4 vCPU, 16 GiB) | ~$125 USD |
 | Public IP | Standard, Static | ~$4 USD |
 | OS Disk | 30 GiB Premium SSD | ~$5 USD |
 | VNet + NSG | — | No additional cost |
-| **Total** | | **~$39 USD/month** |
+| **Total** | | **~$134 USD/month** |
 
 :::tip
 Use `terraform destroy` when the lab is not in use to avoid ongoing charges. See [Teardown](07-teardown/) for the procedure.

--- a/docs/03-deploy.mdx
+++ b/docs/03-deploy.mdx
@@ -1,6 +1,6 @@
 ---
 title: Deploy
-description: Complete Terraform HCL (main.tf, variables.tf, network.tf, vm.tf, outputs.tf, cloud-init.yaml) for deploying the CDN edge node as an Azure Standard_B2s Ubuntu 24.04 VM with VNet, PIP, NSG, and NGINX caching reverse proxy provisioned via cloud-init
+description: Complete Terraform HCL (main.tf, variables.tf, network.tf, vm.tf, outputs.tf, cloud-init.yaml) for deploying the performance-optimized CDN edge node as an Azure Standard_D4s_v5 (4 vCPU, 16 GiB) Ubuntu 24.04 VM with kernel tuning, NGINX proxy buffer optimization, 25 GB disk cache, upstream keepalive, gzip compression, and 67+ CDN vendor headers provisioned via cloud-init
 sidebar:
   order: 3
 ---
@@ -58,9 +58,9 @@ variable "location" {
 }
 
 variable "vm_size" {
-  description = "Azure VM size (Standard_B2s provides 2 vCPU, 4 GiB RAM)"
+  description = "Azure VM size (Standard_D4s_v5 provides 4 vCPU, 16 GiB RAM, non-burstable)"
   type        = string
-  default     = "Standard_B2s"
+  default     = "Standard_D4s_v5"
 }
 
 variable "admin_username" {
@@ -76,9 +76,15 @@ variable "ssh_public_key_path" {
 }
 
 variable "origin_server" {
-  description = "Origin server URL that the CDN edge forwards cache misses to (e.g., the F5 XC HTTP LB VIP). Use scheme://host format."
+  description = "Origin server URL for proxy_pass (scheme://host format)"
   type        = string
   default     = "http://20.12.78.159"
+}
+
+variable "origin_host" {
+  description = "Origin server host:port for NGINX upstream block (no scheme)"
+  type        = string
+  default     = "20.12.78.159:80"
 }
 
 variable "environment_tag" {
@@ -230,6 +236,7 @@ resource "azurerm_linux_virtual_machine" "edge" {
 
   custom_data = base64encode(templatefile("${path.module}/cloud-init.yaml", {
     origin_server = var.origin_server
+    origin_host   = var.origin_host
   }))
 
   tags = azurerm_resource_group.cdn.tags
@@ -238,7 +245,9 @@ resource "azurerm_linux_virtual_machine" "edge" {
 
 ### Cloud-Init Provisioning
 
-Create `cloud-init.yaml`. This installs NGINX and deploys the full CDN edge configuration with headers from all five major CDN vendors. See [NGINX Configuration](../04-nginx-config/) for the complete header reference.
+Create `cloud-init.yaml`. This is the production-optimized configuration verified under 48 hours of continuous load testing at 170K req/s peak. It provisions kernel tuning, systemd limits, NGINX with performance-optimized buffers, 25 GB disk cache, upstream keepalive, gzip compression, and 67+ CDN vendor headers. See [NGINX Configuration](../04-nginx-config/) for the complete header and tuning reference.
+
+The cloud-init uses Terraform template variables: `${origin_server}` for the proxy_pass URL, `${origin_host}` for the upstream server address. NGINX variables like `${request_id}` must be escaped as `$${request_id}` in the Terraform templatefile.
 
 ```yaml
 #cloud-config
@@ -253,23 +262,122 @@ packages:
   - nginx
 
 write_files:
+  # Kernel tuning for high-throughput proxy
+  - path: /etc/sysctl.d/99-cdn-tuning.conf
+    content: |
+      net.core.somaxconn = 65535
+      net.core.netdev_max_backlog = 65535
+      net.ipv4.tcp_max_syn_backlog = 65535
+      net.ipv4.tcp_tw_reuse = 1
+      net.ipv4.ip_local_port_range = 1024 65535
+      net.core.rmem_max = 16777216
+      net.core.wmem_max = 16777216
+      net.ipv4.tcp_rmem = 4096 87380 16777216
+      net.ipv4.tcp_wmem = 4096 65536 16777216
+      net.ipv4.tcp_fin_timeout = 15
+      net.ipv4.tcp_keepalive_time = 300
+      net.ipv4.tcp_keepalive_intvl = 15
+      net.ipv4.tcp_keepalive_probes = 5
+      net.ipv4.tcp_slow_start_after_idle = 0
+      net.ipv4.tcp_max_tw_buckets = 2000000
+      fs.file-max = 2097152
+      vm.swappiness = 10
+
+  # Systemd file descriptor limits for NGINX
+  - path: /etc/systemd/system/nginx.service.d/override.conf
+    content: |
+      [Service]
+      LimitNOFILE=65535
+      LimitNPROC=65535
+
+  # OS-level limits for www-data
+  - path: /etc/security/limits.d/99-nginx.conf
+    content: |
+      www-data soft nofile 65535
+      www-data hard nofile 65535
+
+  # NGINX main config (performance-optimized)
+  - path: /etc/nginx/nginx.conf
+    content: |
+      user www-data;
+      worker_processes auto;
+      worker_rlimit_nofile 65535;
+      pid /run/nginx.pid;
+      error_log /var/log/nginx/error.log;
+      include /etc/nginx/modules-enabled/*.conf;
+
+      events {
+          use epoll;
+          worker_connections 8192;
+          multi_accept on;
+          accept_mutex off;
+      }
+
+      http {
+          sendfile on;
+          tcp_nopush on;
+          tcp_nodelay on;
+          types_hash_max_size 2048;
+          server_tokens off;
+
+          include /etc/nginx/mime.types;
+          default_type application/octet-stream;
+
+          log_format cdn '$remote_addr [$time_local] "$request" $status $body_bytes_sent $upstream_cache_status $request_time';
+          access_log /var/log/nginx/access.log cdn buffer=256k flush=5s;
+
+          keepalive_timeout 65;
+          keepalive_requests 100000;
+
+          proxy_buffering on;
+          proxy_buffer_size 16k;
+          proxy_buffers 64 16k;
+          proxy_busy_buffers_size 256k;
+
+          gzip on;
+          gzip_comp_level 4;
+          gzip_min_length 256;
+          gzip_vary on;
+          gzip_proxied any;
+          gzip_types text/plain text/css text/javascript text/xml
+                     application/json application/javascript application/xml
+                     application/xml+rss application/atom+xml
+                     application/ld+json application/manifest+json
+                     image/svg+xml;
+
+          open_file_cache max=200000 inactive=20s;
+          open_file_cache_valid 30s;
+          open_file_cache_min_uses 2;
+          open_file_cache_errors on;
+
+          include /etc/nginx/conf.d/*.conf;
+      }
+
+  # CDN edge proxy config
   - path: /etc/nginx/conf.d/cdn-edge.conf
     content: |
       proxy_cache_path /var/cache/nginx/cdn
                        levels=1:2
-                       keys_zone=cdn_cache:10m
-                       max_size=1g
-                       inactive=60m
+                       keys_zone=cdn_cache:32m
+                       max_size=25g
+                       inactive=24h
                        use_temp_path=off;
 
+      upstream origin_backend {
+          server ${origin_host};
+          keepalive 256;
+          keepalive_timeout 60s;
+          keepalive_requests 1000;
+      }
+
       map $request_id $cdn_ray_id {
-          default "${request_id}-SJC";
+          default "$${request_id}-SJC";
       }
       map $request_id $cdn_azure_ref {
-          default "0${request_id}AAAAAA";
+          default "0$${request_id}AAAAAA";
       }
       map $request_id $cdn_amz_cf_id {
-          default "E1${request_id}==";
+          default "E1$${request_id}==";
       }
       map $http_user_agent $is_mobile {
           default "false";
@@ -285,7 +393,7 @@ write_files:
       }
 
       server {
-          listen 80;
+          listen 80 reuseport;
           server_name _;
 
           location /health {
@@ -295,20 +403,27 @@ write_files:
           }
 
           location / {
-              proxy_pass ${origin_server};
+              proxy_pass http://origin_backend;
+              proxy_http_version 1.1;
+              proxy_set_header Connection "";
+              proxy_read_timeout 30s;
+              proxy_connect_timeout 10s;
+              proxy_send_timeout 15s;
 
-              # Industry standard headers
+              # Standard headers
               proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
               proxy_set_header X-Forwarded-Proto  $scheme;
               proxy_set_header X-Forwarded-Host   $host;
+              proxy_set_header X-Forwarded-Port   $server_port;
               proxy_set_header X-Real-IP          $remote_addr;
               proxy_set_header Via                "1.1 cdn-simulator";
+              proxy_set_header Forwarded          "for=$remote_addr;proto=$scheme;host=$host";
               proxy_set_header CDN-Loop           "cdn-simulator";
 
               # Akamai
               proxy_set_header True-Client-IP              $remote_addr;
-              proxy_set_header X-Akamai-Edgescape          "georegion=263,country_code=US,region_code=CA,city=SANJOSE,dma=807,lat=37.3353,long=-121.8938,timezone=PST,continent=NA,throughput=vhigh,asnum=7018,network_type=broadband";
-              proxy_set_header X-Akamai-Device-Characteristics "is_mobile=$is_mobile;is_tablet=$is_tablet;is_wireless_device=$is_mobile";
+              proxy_set_header X-Akamai-Edgescape          "georegion=263,country_code=US,region_code=CA,city=SANJOSE,dma=807,pmsa=7400,msa=7362,areacode=408,county=SANTACLARA,fips=06085,lat=37.3353,long=-121.8938,timezone=PST,zip=95113-95196,continent=NA,throughput=vhigh,bw=5000,network=att.net,asnum=7018,network_type=broadband";
+              proxy_set_header X-Akamai-Device-Characteristics "brand_name=Generic;model_name=Browser;is_mobile=$is_mobile;is_tablet=$is_tablet;is_wireless_device=$is_mobile;device_os=Linux;device_os_version=1.0;resolution_width=1920;resolution_height=1080";
               proxy_set_header X-Akamai-Request-ID         $request_id;
 
               # Cloudflare
@@ -320,50 +435,79 @@ write_files:
               proxy_set_header cf-iplongitude      "-121.8938";
               proxy_set_header cf-region           "California";
               proxy_set_header cf-region-code      "CA";
+              proxy_set_header cf-metro-code       "807";
+              proxy_set_header cf-postal-code      "95113";
               proxy_set_header cf-timezone         "America/Los_Angeles";
               proxy_set_header Cf-Ray             $cdn_ray_id;
               proxy_set_header CF-Visitor         '{"scheme":"https"}';
               proxy_set_header cf-bot-score       "85";
+              proxy_set_header cf-verified-bot    "false";
               proxy_set_header cf-ja3-hash        "e7d705a3286e19ea42f587b344ee6865";
+              proxy_set_header cf-ja4             "t13d1516h2_8daaf6152771_b0da82dd1658";
 
-              # Amazon CloudFront
+              # CloudFront
               proxy_set_header CloudFront-Viewer-Address         "$remote_addr:$remote_port";
               proxy_set_header CloudFront-Viewer-Country         "US";
               proxy_set_header CloudFront-Viewer-Country-Name    "United States";
+              proxy_set_header CloudFront-Viewer-Country-Region  "CA";
+              proxy_set_header CloudFront-Viewer-Country-Region-Name "California";
               proxy_set_header CloudFront-Viewer-City            "San Jose";
+              proxy_set_header CloudFront-Viewer-Postal-Code     "95113";
               proxy_set_header CloudFront-Viewer-Latitude        "37.33530";
               proxy_set_header CloudFront-Viewer-Longitude       "-121.89300";
+              proxy_set_header CloudFront-Viewer-Time-Zone       "America/Los_Angeles";
+              proxy_set_header CloudFront-Viewer-Metro-Code      "807";
+              proxy_set_header CloudFront-Viewer-ASN             "7018";
+              proxy_set_header CloudFront-Viewer-Http-Version    "2.0";
+              proxy_set_header CloudFront-Forwarded-Proto        "https";
               proxy_set_header CloudFront-Viewer-TLS             "TLSv1.3:TLS_AES_128_GCM_SHA256:sessionResumed";
+              proxy_set_header CloudFront-Viewer-JA3-Fingerprint "e7d705a3286e19ea42f587b344ee6865";
               proxy_set_header CloudFront-Is-Desktop-Viewer      $is_desktop;
               proxy_set_header CloudFront-Is-Mobile-Viewer       $is_mobile;
               proxy_set_header CloudFront-Is-Tablet-Viewer       $is_tablet;
+              proxy_set_header CloudFront-Is-SmartTV-Viewer      "false";
               proxy_set_header X-Amz-Cf-Id                       $cdn_amz_cf_id;
 
               # Fastly
               proxy_set_header Fastly-Client-IP    $remote_addr;
               proxy_set_header Fastly-SSL          "1";
+              proxy_set_header Fastly-Client       "1";
+              proxy_set_header Fastly-FF           "cache-sjc3120-SJC";
               proxy_set_header X-Geo-Country-Code  "US";
+              proxy_set_header X-Geo-Country-Code3 "USA";
+              proxy_set_header X-Geo-Country-Name  "United States";
               proxy_set_header X-Geo-City          "San Jose";
               proxy_set_header X-Geo-Region        "CA";
               proxy_set_header X-Geo-Continent-Code "NA";
+              proxy_set_header X-Geo-Latitude      "37.3353";
+              proxy_set_header X-Geo-Longitude     "-121.8938";
+              proxy_set_header X-Geo-Postal-Code   "95113";
+              proxy_set_header X-Geo-Metro-Code    "807";
+              proxy_set_header X-Geo-ASN           "7018";
+              proxy_set_header X-Geo-Conn-Speed    "broadband";
+              proxy_set_header X-Geo-Conn-Type     "wired";
 
               # Azure Front Door
               proxy_set_header X-Azure-ClientIP    $remote_addr;
               proxy_set_header X-Azure-SocketIP    $remote_addr;
               proxy_set_header X-Azure-Ref         $cdn_azure_ref;
               proxy_set_header X-Azure-FDID        "a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1";
+              proxy_set_header X-Azure-RequestChain "hops=1";
 
-              # CDN caching
+              # Cache (performance-optimized)
               proxy_set_header Host $host;
               proxy_cache cdn_cache;
-              proxy_cache_valid 200 301 302 10m;
+              proxy_cache_valid 200 301 302 4h;
               proxy_cache_valid 404 1m;
               proxy_cache_key "$scheme$host$request_uri";
-              proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
-              proxy_ignore_headers Set-Cookie;
-              proxy_cache_bypass $http_cache_control;
+              proxy_cache_lock on;
+              proxy_cache_lock_age 3s;
+              proxy_cache_lock_timeout 3s;
+              proxy_cache_revalidate on;
+              proxy_cache_background_update on;
+              proxy_cache_use_stale updating error timeout http_500 http_502 http_503 http_504;
+              proxy_ignore_headers Set-Cookie Cache-Control Expires;
 
-              # Response headers
               add_header X-Cache-Status     $upstream_cache_status always;
               add_header X-CDN-Edge         "cdn-simulator" always;
               add_header X-CDN-POP          "SJC" always;
@@ -376,6 +520,8 @@ write_files:
     content: ""
 
 runcmd:
+  - sysctl -p /etc/sysctl.d/99-cdn-tuning.conf
+  - systemctl daemon-reload
   - rm -f /etc/nginx/sites-enabled/default
   - chown -R www-data:www-data /var/cache/nginx/cdn
   - nginx -t
@@ -422,10 +568,11 @@ Create `terraform.tfvars.example`:
 subscription_id     = "00000000-0000-0000-0000-000000000000"
 resource_group_name = "rg-cdn-simulator"
 location            = "eastus2"
-vm_size             = "Standard_B2s"
+vm_size             = "Standard_D4s_v5"
 admin_username      = "azureuser"
 ssh_public_key_path = "~/.ssh/id_ed25519.pub"
 origin_server       = "http://20.12.78.159"
+origin_host         = "20.12.78.159:80"
 environment_tag     = "lab"
 ```
 


### PR DESCRIPTION
## Summary

- Update VM size from Standard_B2s to Standard_D4s_v5 and correct monthly cost estimate from $39 to $134 in prerequisites
- Replace entire cloud-init block in deploy guide with production configuration verified under 48-hour load test at 170K req/s peak
- New config includes kernel tuning, systemd file limits, NGINX epoll/reuseport, 8192 worker_connections, 64x16k proxy buffers, 25g cache with 24h inactive/4h TTL, upstream keepalive 256/worker, gzip level 4, open_file_cache, buffered logging, and proxy_cache_lock with background_update

Closes #16

## Test plan

- [ ] CI checks pass (Check linked issues, Lint Code Base)
- [ ] Verify `docs/02-prerequisites.mdx` shows Standard_D4s_v5 and $134/mo
- [ ] Verify `docs/03-deploy.mdx` cloud-init matches production config
- [ ] Docs site builds and renders correctly after merge