### PR TITLE
fix: correct remark-code-import file paths for docs-builder container

### DIFF
--- a/docs/03-deploy.mdx
+++ b/docs/03-deploy.mdx
@@ -20,26 +20,26 @@ cp terraform.tfvars.example terraform.tfvars
 
 `main.tf` configures the Azure provider:
 
-```hcl file=../terraform/main.tf
+```hcl file=./_data/main.tf
 ```
 
 `variables.tf` defines all configurable parameters. The `vm_size` default is `Standard_F4s_v2` (4 vCPU, 8 GiB) — see [VM Sizing](#vm-sizing) for scaling guidance:
 
-```hcl file=../terraform/variables.tf
+```hcl file=./_data/variables.tf
 ```
 
 ### Network Infrastructure
 
 `network.tf` creates the VNet, subnet, public IP, NSG (ports 22/80/443), and NIC:
 
-```hcl file=../terraform/network.tf
+```hcl file=./_data/network.tf
 ```
 
 ### Virtual Machine with Cloud-Init
 
 `vm.tf` creates the Ubuntu 24.04 VM and passes the cloud-init template with origin server variables:
 
-```hcl file=../terraform/vm.tf
+```hcl file=./_data/vm.tf
 ```
 
 ### Cloud-Init Provisioning
@@ -48,21 +48,21 @@ cp terraform.tfvars.example terraform.tfvars
 
 The cloud-init uses Terraform template variables: `${origin_host}` for the upstream server address. NGINX variables like `${request_id}` must be escaped as `$${request_id}` in the Terraform templatefile.
 
-```yaml file=../terraform/cloud-init.yaml
+```yaml file=./_data/cloud-init.yaml
 ```
 
 ### Outputs
 
 `outputs.tf` exposes the public IP, SSH command, edge URL, and health check endpoint:
 
-```hcl file=../terraform/outputs.tf
+```hcl file=./_data/outputs.tf
 ```
 
 ### Example Variables File
 
 Copy `terraform.tfvars.example` to `terraform.tfvars` and fill in your values. The `.gitignore` excludes `terraform.tfvars` to prevent committing credentials:
 
-```hcl file=../terraform/terraform.tfvars.example
+```hcl file=./_data/terraform.tfvars.example
 ```
 
 ## Deploy


### PR DESCRIPTION
## Summary

- Fix `file=` references in `docs/03-deploy.mdx` from `../terraform/` to `./_data/` to match docs-builder container mount points
- The docs-control pipeline stages terraform files at `_data/` inside the content directory; MDX imports must reference that path at build time
- Without this fix, code blocks render empty in published docs and `llms-full.txt`

Closes #38

## Test plan

- [ ] CI checks pass (Check linked issues, Lint Code Base)
- [ ] Docs build succeeds with correct code block content in `03-deploy.mdx`
- [ ] `llms-full.txt` contains the terraform code snippets