### PR TITLE
fix: auto-generate unique resource group name per Azure user identity

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -13,3 +13,12 @@ provider "azurerm" {
   features {}
   subscription_id = var.subscription_id
 }
+
+data "azurerm_client_config" "current" {}
+
+locals {
+  # Deterministic 8-char suffix derived from the authenticated user's Azure object_id.
+  # Same person always gets the same suffix across destroy/redeploy cycles.
+  suffix              = substr(sha1(data.azurerm_client_config.current.object_id), 0, 8)
+  resource_group_name = var.resource_group_name != "" ? var.resource_group_name : "rg-cdn-simulator-${local.suffix}"
+}

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -1,5 +1,5 @@
 resource "azurerm_resource_group" "cdn" {
-  name     = var.resource_group_name
+  name     = local.resource_group_name
   location = var.location
 
   tags = {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -4,9 +4,9 @@ variable "subscription_id" {
 }
 
 variable "resource_group_name" {
-  description = "Name for the Azure resource group"
+  description = "Name for the Azure resource group (leave empty to auto-generate from your Azure identity)"
   type        = string
-  default     = "rg-cdn-simulator"
+  default     = ""
 }
 
 variable "location" {


### PR DESCRIPTION
## Summary

- Adds `azurerm_client_config` data source and `locals` block to derive a deterministic 8-char sha1 suffix from the authenticated user's Azure `object_id`
- Changes `resource_group_name` default from `rg-cdn-simulator` to empty string to trigger auto-generation
- Updates `azurerm_resource_group.cdn` to use `local.resource_group_name` instead of `var.resource_group_name`

This prevents collisions when multiple SEs deploy to the same Azure subscription.

Closes #46

## Test plan

- [ ] CI checks pass
- [ ] `terraform plan` shows deterministic resource group name generation
- [ ] Explicit `resource_group_name` override still works