### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -13,7 +13,7 @@ skip-path:
   - specs/raw
   - specs/original
   # Install-verification dockerfiles are test harnesses, not production
-  # images - CKV_DOCKER_2 (HEALTHCHECK) and CKV_DOCKER_3 (non-root user)
+  # images — CKV_DOCKER_2 (HEALTHCHECK) and CKV_DOCKER_3 (non-root user)
   # are not meaningful for ephemeral CI validation containers.
   - scripts/install-tests
 
@@ -29,14 +29,29 @@ framework:
 
 # ── Check exclusions ─────────────────────────────────────────────────────────
 skip-check:
-  - CKV_GHA_7    # GitHub Actions - allow pinning to branch refs
-  - CKV2_GHA_1   # GitHub Actions - immutable actions (covered by Dependabot)
+  - CKV_GHA_7    # GitHub Actions — allow pinning to branch refs
+  - CKV2_GHA_1   # GitHub Actions — immutable actions (covered by Dependabot)
+  - CKV_GHA_1    # GitHub Actions — ACTIONS_ALLOW_UNSECURE_COMMANDS not used
+  - CKV_GHA_2    # GitHub Actions — managed workflows use controlled inputs
+  - CKV_GHA_3    # GitHub Actions — curl with secrets in managed deploy scripts
+  - CKV_GHA_4    # GitHub Actions — no netcat usage in managed workflows
+  - CKV_GHA_5    # GitHub Actions — cosign signing not required for this org
+  - CKV_GHA_6    # GitHub Actions — cosign SBOM attestation not required
   - "CKV_SECRET_4:.*specifications/api/.*\\.json$"
-  - CKV_AZURE_10   # Lab NSG - SSH open for demo access
-  - CKV_AZURE_93   # Lab VM - platform-managed encryption sufficient
-  - CKV_AZURE_149  # Lab VM - persistent OS disk required for cloud-init config
-  - CKV_AZURE_160  # Lab NSG - HTTP port 80 required for CDN traffic
-  - CKV_AZURE_220  # Lab NSG - SSH open for demo access
-  - CKV_AZURE_50   # Lab VM - no extensions required
-  - CKV_AZURE_119  # Lab NIC - public IP required for demo access
-  - CKV2_AZURE_31  # Lab subnet - NSG associated at NIC level
+  - CKV_AZURE_1    # Lab VM — SSH key auth configured via cloud-init
+  - CKV_AZURE_9    # Lab NSG — RDP not used, SSH only
+  - CKV_AZURE_10   # Lab NSG — SSH open for demo access
+  - CKV_AZURE_50   # Lab VM — extensions not required
+  - CKV_AZURE_77   # Lab NSG — UDP services open for demo traffic
+  - CKV_AZURE_92   # Lab VM — managed disks used by default
+  - CKV_AZURE_93   # Lab VM — platform-managed encryption sufficient
+  - CKV_AZURE_118  # Lab NIC — IP forwarding disabled by default
+  - CKV_AZURE_119  # Lab NIC — public IP required for demo access
+  - CKV_AZURE_149  # Lab VM — password auth disabled, SSH keys used
+  - CKV_AZURE_160  # Lab NSG — HTTP port 80 required for demo traffic
+  - CKV_AZURE_178  # Lab VM — SSH keys configured via cloud-init
+  - CKV_AZURE_179  # Lab VM — agent installed via cloud-init
+  - CKV_AZURE_182  # Lab VNET — single DNS endpoint sufficient for demos
+  - CKV_AZURE_183  # Lab VNET — Azure default DNS sufficient for demos
+  - CKV_AZURE_220  # Lab NSG — SSH open for demo access
+  - CKV2_AZURE_31  # Lab subnet — NSG associated at NIC level

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = *.json,*.lock,*/tools/generated/*,vendor/*,*/vendored/*,*-vendored*,*/fixtures/*,*.min.js,*.jsonl,*.b64.js,*/gen/*,node_modules,target,dist,.git,packages/*/dist,crates/*/vendored
-ignore-words-list = afterall,aks,anull,datas,edn,hcl,ists,iterm,nd,observ,pre-select,pre-selected,pre-selects,preceeding,uncomplete,ves,doesnt,forin,statics,ser,anc,abd,fo,te,runn,crossreferences,prevend,aline,invokable,takin,hel,unparseable,defaul,doub,cros,deine
+ignore-words-list = afterall,aks,anull,datas,edn,hcl,ists,iterm,nd,nin,observ,pre-select,pre-selected,pre-selects,preceeding,uncomplete,ves,doesnt,forin,statics,ser,anc,abd,fo,te,runn,crossreferences,prevend,aline,invokable,takin,hel,unparseable,defaul,doub,cros,deine

--- a/.editorconfig
+++ b/.editorconfig
@@ -18,5 +18,9 @@ indent_size = unset
 [*.py]
 indent_size = 4
 
+[*.go]
+indent_style = tab
+indent_size = 4
+
 [Makefile]
 indent_style = tab

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,6 +1,7 @@
 [mypy]
 python_version = 3.11
 ignore_missing_imports = True
+exclude = (?x)(\.mdx$)
 check_untyped_defs = True
 warn_return_any = False
 disallow_untyped_defs = False

--- a/.python-lint
+++ b/.python-lint
@@ -1,6 +1,7 @@
 [MAIN]
 py-version = 3.11
 jobs = 0
+ignore-paths = ^.*\.mdx$
 
 [FORMAT]
 max-line-length = 88

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,5 +1,6 @@
 line-length = 88
 target-version = "py313"
+extend-exclude = ["*.mdx"]
 
 [format]
 quote-style = "double"

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -2,3 +2,20 @@
 # All single-quoted $var references in this repo are intentional jq variables,
 # not missed shell expansions.
 disable=SC2016
+
+# Disable SC1091: Not following sourced file.
+# Scripts source relative-path libraries (_lib.sh, _crapi-lib.sh, etc.)
+# that shellcheck cannot resolve in CI.
+disable=SC1091
+
+# Disable SC2034: Variable appears unused.
+# Scripts set variables consumed by sourced library files or trap handlers.
+disable=SC2034
+
+# Disable SC2064: Use single quotes for trap to prevent early expansion.
+# Scripts intentionally expand variables at trap-set time.
+disable=SC2064
+
+# Disable SC2086: Double quote to prevent globbing and word splitting.
+# Pipeline scripts and attack suites intentionally rely on word splitting.
+disable=SC2086

--- a/biome.json
+++ b/biome.json
@@ -36,6 +36,12 @@
       }
     },
     {
+      "includes": ["docs/specifications/api/**", "docs/api-reference/**"],
+      "formatter": {
+        "enabled": false
+      }
+    },
+    {
       "includes": ["**/*.astro"],
       "linter": {
         "rules": {

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,6 @@
 line-length = 88
 target-version = "py313"
+extend-exclude = ["*.mdx"]
 
 [format]
 quote-style = "double"


### PR DESCRIPTION
Closes #52

Synced managed files from `f5xc-salesdemos/docs-control` canonical source:

- README.md
- .editorconfig
- biome.json
- .checkov.yaml
- .shellcheckrc
- .codespellrc
- .ruff.toml
- ruff.toml
- .python-lint
- .mypy.ini