### PR TITLE
feat(terraform): standardize terraform per Demo Resource Standard

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,20 @@ repos:
         args: ["--branch", "main"]
 
   # ===========================================================================
+  # Terraform formatting and validation
+  # ===========================================================================
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.96.1
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_validate
+      - id: terraform_docs
+        args:
+          - --hook-config=--path-to-file=README.md
+          - --hook-config=--add-to-existing-file=true
+          - --args=--config=.terraform-docs.yml
+
+  # ===========================================================================
   # Repository-specific hooks (escape hatch)
   #
   # Runs scripts/pre-commit-local.sh if present and executable. Repos use
@@ -204,3 +218,6 @@ ci:
     - zizmor
     - checkov
     - gitleaks
+    - terraform_fmt
+    - terraform_validate
+    - terraform_docs

--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,0 +1,19 @@
+formatter: markdown table
+
+content: ""
+
+output:
+  file: ../README.md
+  mode: inject
+
+sort:
+  enabled: true
+  by: required
+
+settings:
+  anchor: true
+  escape: true
+  indent: 2
+  required: true
+  sensitive: true
+  type: true

--- a/README.md
+++ b/README.md
@@ -24,6 +24,82 @@ and usage guides.
 See [CONTRIBUTING.md](CONTRIBUTING.md) for workflow rules,
 branch naming, and CI requirements.
 
+## Terraform Reference
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 3.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 3.8.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.71.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [azurerm_linux_virtual_machine.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine) | resource |
+| [azurerm_network_interface.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface) | resource |
+| [azurerm_network_interface_security_group_association.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface_security_group_association) | resource |
+| [azurerm_network_security_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_group) | resource |
+| [azurerm_public_ip.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
+| [azurerm_resource_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_subnet.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
+| [azurerm_virtual_network.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
+| [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/client_config) | data source |
+| [azuread_user.current](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/user) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_origin_host"></a> [origin\_host](#input\_origin\_host) | Origin server host:port for NGINX upstream (no scheme). Use IP:443 for HTTPS or IP:80 for HTTP. | `string` | n/a | yes |
+| <a name="input_origin_server"></a> [origin\_server](#input\_origin\_server) | Origin server URL for cache miss forwarding (e.g., an HTTPS VIP or a direct HTTP origin IP) | `string` | n/a | yes |
+| <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | Azure subscription ID | `string` | n/a | yes |
+| <a name="input_admin_username"></a> [admin\_username](#input\_admin\_username) | SSH admin username for the VM | `string` | `"azureuser"` | no |
+| <a name="input_deployer"></a> [deployer](#input\_deployer) | Override for deployer identifier (auto-resolved from Azure AD if empty). Required for service principal or managed identity authentication. | `string` | `""` | no |
+| <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | OS disk size in GB | `number` | `30` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment label used in resource group naming and tags | `string` | `"lab"` | no |
+| <a name="input_location"></a> [location](#input\_location) | Azure region for all resources | `string` | `"eastus2"` | no |
+| <a name="input_ssh_public_key_path"></a> [ssh\_public\_key\_path](#input\_ssh\_public\_key\_path) | Path to the SSH public key file | `string` | `"~/.ssh/id_ed25519.pub"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags merged with standard tags (component, environment, deployer, managed\_by) | `map(string)` | `{}` | no |
+| <a name="input_vm_size"></a> [vm\_size](#input\_vm\_size) | Azure VM size — F-series compute-optimized recommended (F4s\_v2 for lab, F16s\_v2 for load testing, F32s\_v2 for production) | `string` | `"Standard_F4s_v2"` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_component"></a> [component](#output\_component) | Component name |
+| <a name="output_deployer"></a> [deployer](#output\_deployer) | Resolved deployer identifier |
+| <a name="output_edge_url"></a> [edge\_url](#output\_edge\_url) | HTTP URL of the CDN edge node |
+| <a name="output_environment"></a> [environment](#output\_environment) | Environment label |
+| <a name="output_health_check_url"></a> [health\_check\_url](#output\_health\_check\_url) | Health check endpoint |
+| <a name="output_location"></a> [location](#output\_location) | Azure region |
+| <a name="output_nsg_id"></a> [nsg\_id](#output\_nsg\_id) | Resource ID of the network security group |
+| <a name="output_nsg_name"></a> [nsg\_name](#output\_nsg\_name) | Name of the network security group |
+| <a name="output_private_ip"></a> [private\_ip](#output\_private\_ip) | Private IP address of the VM |
+| <a name="output_public_ip"></a> [public\_ip](#output\_public\_ip) | Public IP address of the VM |
+| <a name="output_resource_group_id"></a> [resource\_group\_id](#output\_resource\_group\_id) | Resource ID of the resource group |
+| <a name="output_resource_group_name"></a> [resource\_group\_name](#output\_resource\_group\_name) | Name of the resource group |
+| <a name="output_ssh_command"></a> [ssh\_command](#output\_ssh\_command) | SSH command to connect to the VM |
+| <a name="output_subnet_id"></a> [subnet\_id](#output\_subnet\_id) | Resource ID of the subnet |
+| <a name="output_vm_id"></a> [vm\_id](#output\_vm\_id) | Resource ID of the virtual machine |
+| <a name="output_vm_name"></a> [vm\_name](#output\_vm\_name) | Name of the virtual machine |
+| <a name="output_vnet_name"></a> [vnet\_name](#output\_vnet\_name) | Name of the virtual network |
+<!-- END_TF_DOCS -->
+
 ## License
 
 See [LICENSE](LICENSE).

--- a/component-manifest.json
+++ b/component-manifest.json
@@ -1,15 +1,144 @@
 {
-  "schema_version": "1",
+  "schema_version": "2",
   "name": "cdn-simulator",
+  "display_name": "CDN Simulator",
   "role": "NGINX-based CDN edge node simulator",
   "category": "lab-infrastructure",
   "summary": "Azure Ubuntu 24.04 VM running NGINX as a CDN edge node simulator with 67+ vendor-specific headers (Akamai, Cloudflare, CloudFront, Fastly, Azure Front Door), cache behavior simulation, and origin pull for testing F5 XC CDN integration scenarios",
+
   "provides": ["cdn-edge-simulation", "vendor-header-injection", "cache-behavior-testing", "origin-pull"],
   "pairs_with": ["origin-server"],
   "demos": ["cdn"],
+
   "terraform": {
-    "required_vars": ["subscription_id", "origin_server", "origin_host"],
-    "vm_size": "Standard_F4s_v2",
-    "estimated_monthly_cost": "$122"
+    "required_inputs": {
+      "subscription_id": {
+        "type": "string",
+        "description": "Azure subscription ID"
+      },
+      "origin_server": {
+        "type": "string",
+        "description": "Origin server URL that the CDN edge forwards cache misses to"
+      },
+      "origin_host": {
+        "type": "string",
+        "description": "Origin server host:port for NGINX upstream (no scheme)"
+      }
+    },
+    "optional_inputs": {
+      "deployer": {
+        "type": "string",
+        "default": "",
+        "description": "Override for deployer identifier (auto-resolved from Azure AD if empty)"
+      },
+      "location": {
+        "type": "string",
+        "default": "eastus2",
+        "description": "Azure region for all resources"
+      },
+      "environment": {
+        "type": "string",
+        "default": "lab",
+        "description": "Environment label used in resource group naming and tags"
+      },
+      "vm_size": {
+        "type": "string",
+        "default": "Standard_F4s_v2",
+        "description": "Azure VM size"
+      },
+      "disk_size_gb": {
+        "type": "number",
+        "default": 30,
+        "description": "OS disk size in GB"
+      },
+      "admin_username": {
+        "type": "string",
+        "default": "azureuser",
+        "description": "SSH admin username for the VM"
+      },
+      "ssh_public_key_path": {
+        "type": "string",
+        "default": "~/.ssh/id_ed25519.pub",
+        "description": "Path to the SSH public key file"
+      },
+      "tags": {
+        "type": "map(string)",
+        "default": {},
+        "description": "Additional tags merged with standard tags"
+      }
+    },
+    "standard_outputs": [
+      "deployer",
+      "resource_group_name",
+      "resource_group_id",
+      "location",
+      "public_ip",
+      "private_ip",
+      "ssh_command",
+      "vm_name",
+      "vm_id",
+      "nsg_name",
+      "nsg_id",
+      "vnet_name",
+      "subnet_id",
+      "component",
+      "environment"
+    ],
+    "component_outputs": {
+      "edge_url": {
+        "type": "string",
+        "description": "HTTP URL of the CDN edge node"
+      },
+      "health_check_url": {
+        "type": "string",
+        "description": "Health check endpoint"
+      }
+    },
+    "estimated_monthly_cost": "$122",
+    "vm_image": {
+      "publisher": "Canonical",
+      "offer": "ubuntu-24_04-lts",
+      "sku": "server",
+      "version": "latest"
+    }
+  },
+
+  "nsg_rules": [
+    {
+      "name": "AllowHTTP",
+      "priority": 100,
+      "direction": "Inbound",
+      "access": "Allow",
+      "protocol": "Tcp",
+      "destination_port_range": "80",
+      "source_address_prefix": "*",
+      "description": "HTTP traffic for CDN edge requests"
+    },
+    {
+      "name": "AllowHTTPS",
+      "priority": 110,
+      "direction": "Inbound",
+      "access": "Allow",
+      "protocol": "Tcp",
+      "destination_port_range": "443",
+      "source_address_prefix": "*",
+      "description": "HTTPS traffic for CDN edge requests"
+    },
+    {
+      "name": "AllowSSH",
+      "priority": 120,
+      "direction": "Inbound",
+      "access": "Allow",
+      "protocol": "Tcp",
+      "destination_port_range": "22",
+      "source_address_prefix": "*",
+      "description": "SSH access for administration"
+    }
+  ],
+
+  "health_check": {
+    "path": "/health",
+    "port": 80,
+    "expected_status": 200
   }
 }

--- a/docs/llms-config.json
+++ b/docs/llms-config.json
@@ -1,14 +1,14 @@
 {
   "customSets": [
     {
-      "label": "Deployment Guide",
-      "description": "Step-by-step CDN simulator deployment from overview through verification",
-      "paths": ["01-overview*", "02-prerequisites*", "03-deploy*", "04-nginx-config*", "05-verify*"]
+      "label": "Deployment",
+      "description": "Terraform IaC deployment with prerequisites and teardown",
+      "paths": ["02-prerequisites*", "03-deploy*", "07-teardown*"]
     },
     {
-      "label": "Integration",
-      "description": "Integration with F5 XC HTTP load balancers",
-      "paths": ["06-integrate*"]
+      "label": "CDN Configuration",
+      "description": "NGINX CDN edge configuration, vendor headers, and cache behavior",
+      "paths": ["01-overview*", "04-nginx-config*", "05-verify*", "06-integrate*"]
     }
   ],
   "promote": ["index*", "01-overview*", "03-deploy*"],

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,0 +1,6 @@
+data "azuread_client_config" "current" {}
+
+data "azuread_user" "current" {
+  count     = var.deployer == "" ? 1 : 0
+  object_id = data.azuread_client_config.current.object_id
+}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,14 +1,24 @@
 locals {
   component = "cdn-simulator"
 
-  # --- Deployer resolution (3-tier fallback) ---
+  # --- Deployer resolution (4-tier fallback) ---
   # 1. Explicit override via var.deployer
-  # 2. Azure AD user: first-initial + surname
-  # 3. Object ID hash (service principals, managed identities)
-  deployer_from_user = (
+  # 2a. Azure AD: given_name initial + surname (e.g., "Robin" + "Mordasiewicz" → rmordasiewicz)
+  # 2b. Azure AD: mail prefix (e.g., R.Mordasiewicz@F5.com → rmordasiewicz)
+  # 3. Object ID hash (service principals, managed identities, missing profile data)
+  deployer_from_name = (
     var.deployer == "" && length(data.azuread_user.current) > 0
     ? try(
       lower("${substr(data.azuread_user.current[0].given_name, 0, 1)}${data.azuread_user.current[0].surname}"),
+      ""
+    )
+    : ""
+  )
+
+  deployer_from_mail = (
+    var.deployer == "" && length(data.azuread_user.current) > 0 && local.deployer_from_name == ""
+    ? try(
+      lower(split("@", data.azuread_user.current[0].mail)[0]),
       ""
     )
     : ""
@@ -18,7 +28,8 @@ locals {
 
   deployer_resolved = coalesce(
     var.deployer,
-    local.deployer_from_user,
+    local.deployer_from_name,
+    local.deployer_from_mail,
     local.deployer_from_oid
   )
 

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,0 +1,47 @@
+locals {
+  component = "cdn-simulator"
+
+  # --- Deployer resolution (3-tier fallback) ---
+  # 1. Explicit override via var.deployer
+  # 2. Azure AD user: first-initial + surname
+  # 3. Object ID hash (service principals, managed identities)
+  deployer_from_user = (
+    var.deployer == "" && length(data.azuread_user.current) > 0
+    ? try(
+      lower("${substr(data.azuread_user.current[0].given_name, 0, 1)}${data.azuread_user.current[0].surname}"),
+      ""
+    )
+    : ""
+  )
+
+  deployer_from_oid = substr(sha1(data.azuread_client_config.current.object_id), 0, 8)
+
+  deployer_resolved = coalesce(
+    var.deployer,
+    local.deployer_from_user,
+    local.deployer_from_oid
+  )
+
+  deployer = replace(lower(local.deployer_resolved), "/[^a-z0-9]/", "")
+
+  # --- Resource naming (Cloud Adoption Framework) ---
+  name = {
+    resource_group    = "rg-${local.component}-${var.environment}-${local.deployer}"
+    virtual_network   = "vnet-${local.component}-${local.deployer}"
+    subnet            = "snet-${local.component}-${local.deployer}"
+    public_ip         = "pip-${local.component}-${local.deployer}"
+    nsg               = "nsg-${local.component}-${local.deployer}"
+    network_interface = "nic-${local.component}-${local.deployer}"
+    virtual_machine   = "vm-${local.component}-${local.deployer}"
+  }
+
+  # --- Standard tags ---
+  standard_tags = {
+    component   = local.component
+    environment = var.environment
+    deployer    = local.deployer
+    managed_by  = "terraform"
+  }
+
+  tags = merge(local.standard_tags, var.tags)
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,24 +1,5 @@
-terraform {
-  required_version = ">= 1.5.0"
-
-  required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 4.0"
-    }
-  }
-}
-
-provider "azurerm" {
-  features {}
-  subscription_id = var.subscription_id
-}
-
-data "azurerm_client_config" "current" {}
-
-locals {
-  # Deterministic 8-char suffix derived from the authenticated user's Azure object_id.
-  # Same person always gets the same suffix across destroy/redeploy cycles.
-  suffix              = substr(sha1(data.azurerm_client_config.current.object_id), 0, 8)
-  resource_group_name = var.resource_group_name != "" ? var.resource_group_name : "rg-cdn-simulator-${local.suffix}"
+resource "azurerm_resource_group" "main" {
+  name     = local.name.resource_group
+  location = var.location
+  tags     = local.tags
 }

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -1,43 +1,33 @@
-resource "azurerm_resource_group" "cdn" {
-  name     = local.resource_group_name
-  location = var.location
-
-  tags = {
-    environment = var.environment_tag
-    component   = "cdn-simulator"
-  }
-}
-
-resource "azurerm_virtual_network" "cdn" {
-  name                = "vnet-cdn-simulator"
+resource "azurerm_virtual_network" "main" {
+  name                = local.name.virtual_network
   address_space       = ["10.100.0.0/16"]
-  location            = azurerm_resource_group.cdn.location
-  resource_group_name = azurerm_resource_group.cdn.name
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 
-  tags = azurerm_resource_group.cdn.tags
+  tags = azurerm_resource_group.main.tags
 }
 
-resource "azurerm_subnet" "edge" {
-  name                 = "snet-edge"
-  resource_group_name  = azurerm_resource_group.cdn.name
-  virtual_network_name = azurerm_virtual_network.cdn.name
+resource "azurerm_subnet" "main" {
+  name                 = local.name.subnet
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.100.1.0/24"]
 }
 
-resource "azurerm_public_ip" "edge" {
-  name                = "pip-cdn-edge"
-  location            = azurerm_resource_group.cdn.location
-  resource_group_name = azurerm_resource_group.cdn.name
+resource "azurerm_public_ip" "main" {
+  name                = local.name.public_ip
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
   allocation_method   = "Static"
   sku                 = "Standard"
 
-  tags = azurerm_resource_group.cdn.tags
+  tags = azurerm_resource_group.main.tags
 }
 
-resource "azurerm_network_security_group" "edge" {
-  name                = "nsg-cdn-edge"
-  location            = azurerm_resource_group.cdn.location
-  resource_group_name = azurerm_resource_group.cdn.name
+resource "azurerm_network_security_group" "main" {
+  name                = local.name.nsg
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 
   security_rule {
     name                       = "AllowHTTP"
@@ -75,25 +65,25 @@ resource "azurerm_network_security_group" "edge" {
     destination_address_prefix = "*"
   }
 
-  tags = azurerm_resource_group.cdn.tags
+  tags = azurerm_resource_group.main.tags
 }
 
-resource "azurerm_network_interface" "edge" {
-  name                = "nic-cdn-edge"
-  location            = azurerm_resource_group.cdn.location
-  resource_group_name = azurerm_resource_group.cdn.name
+resource "azurerm_network_interface" "main" {
+  name                = local.name.network_interface
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 
   ip_configuration {
     name                          = "internal"
-    subnet_id                     = azurerm_subnet.edge.id
+    subnet_id                     = azurerm_subnet.main.id
     private_ip_address_allocation = "Dynamic"
-    public_ip_address_id          = azurerm_public_ip.edge.id
+    public_ip_address_id          = azurerm_public_ip.main.id
   }
 
-  tags = azurerm_resource_group.cdn.tags
+  tags = azurerm_resource_group.main.tags
 }
 
-resource "azurerm_network_interface_security_group_association" "edge" {
-  network_interface_id      = azurerm_network_interface.edge.id
-  network_security_group_id = azurerm_network_security_group.edge.id
+resource "azurerm_network_interface_security_group_association" "main" {
+  network_interface_id      = azurerm_network_interface.main.id
+  network_security_group_id = azurerm_network_security_group.main.id
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,24 +1,92 @@
+# ---------------------------------------------------------
+# Standard Outputs (present in every demo resource)
+# ---------------------------------------------------------
+
+output "deployer" {
+  description = "Resolved deployer identifier"
+  value       = local.deployer
+}
+
+output "resource_group_name" {
+  description = "Name of the resource group"
+  value       = azurerm_resource_group.main.name
+}
+
+output "resource_group_id" {
+  description = "Resource ID of the resource group"
+  value       = azurerm_resource_group.main.id
+}
+
+output "location" {
+  description = "Azure region"
+  value       = azurerm_resource_group.main.location
+}
+
 output "public_ip" {
-  description = "Public IP address of the CDN edge node"
-  value       = azurerm_public_ip.edge.ip_address
+  description = "Public IP address of the VM"
+  value       = azurerm_public_ip.main.ip_address
+}
+
+output "private_ip" {
+  description = "Private IP address of the VM"
+  value       = azurerm_network_interface.main.private_ip_address
 }
 
 output "ssh_command" {
-  description = "SSH command to connect to the edge node"
-  value       = "ssh ${var.admin_username}@${azurerm_public_ip.edge.ip_address}"
+  description = "SSH command to connect to the VM"
+  value       = "ssh ${var.admin_username}@${azurerm_public_ip.main.ip_address}"
 }
+
+output "vm_name" {
+  description = "Name of the virtual machine"
+  value       = azurerm_linux_virtual_machine.main.name
+}
+
+output "vm_id" {
+  description = "Resource ID of the virtual machine"
+  value       = azurerm_linux_virtual_machine.main.id
+}
+
+output "nsg_name" {
+  description = "Name of the network security group"
+  value       = azurerm_network_security_group.main.name
+}
+
+output "nsg_id" {
+  description = "Resource ID of the network security group"
+  value       = azurerm_network_security_group.main.id
+}
+
+output "vnet_name" {
+  description = "Name of the virtual network"
+  value       = azurerm_virtual_network.main.name
+}
+
+output "subnet_id" {
+  description = "Resource ID of the subnet"
+  value       = azurerm_subnet.main.id
+}
+
+output "component" {
+  description = "Component name"
+  value       = local.component
+}
+
+output "environment" {
+  description = "Environment label"
+  value       = var.environment
+}
+
+# ---------------------------------------------------------
+# Component-Specific Outputs
+# ---------------------------------------------------------
 
 output "edge_url" {
   description = "HTTP URL of the CDN edge node"
-  value       = "http://${azurerm_public_ip.edge.ip_address}"
+  value       = "http://${azurerm_public_ip.main.ip_address}"
 }
 
 output "health_check_url" {
   description = "Health check endpoint"
-  value       = "http://${azurerm_public_ip.edge.ip_address}/health"
-}
-
-output "resource_group" {
-  description = "Resource group containing all CDN simulator resources"
-  value       = azurerm_resource_group.cdn.name
+  value       = "http://${azurerm_public_ip.main.ip_address}/health"
 }

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,6 @@
+provider "azurerm" {
+  features {}
+  subscription_id = var.subscription_id
+}
+
+provider "azuread" {}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,21 +1,17 @@
-# Copy this file to terraform.tfvars and fill in your values
-# terraform.tfvars is gitignored — never commit real credentials
+# Copy this file to terraform.tfvars and fill in your values.
+# terraform.tfvars is gitignored — never commit real credentials.
 
-subscription_id     = "00000000-0000-0000-0000-000000000000"
-resource_group_name = "rg-cdn-simulator"
-location            = "eastus2"
-vm_size             = "Standard_F4s_v2"
-admin_username      = "azureuser"
-ssh_public_key_path = "~/.ssh/id_ed25519.pub"
+# --- Required ---
+subscription_id = "00000000-0000-0000-0000-000000000000"
+origin_server   = "http://your-origin-ip"
+origin_host     = "your-origin-ip:80"
 
-# Direct to origin server (HTTP)
-# origin_server = "http://20.12.78.159"
-# origin_host   = "20.12.78.159:80"
-
-# Through F5 Distributed Cloud (HTTPS)
-# origin_server = "https://72.19.3.185"
-# origin_host   = "72.19.3.185:443"
-
-origin_server       = "http://your-origin-ip"
-origin_host         = "your-origin-ip:80"
-environment_tag     = "lab"
+# --- Optional overrides (defaults shown) ---
+# deployer           = ""                       # auto-resolved from Azure AD
+# location           = "eastus2"
+# environment        = "lab"
+# vm_size            = "Standard_F4s_v2"
+# disk_size_gb       = 30
+# admin_username     = "azureuser"
+# ssh_public_key_path = "~/.ssh/id_ed25519.pub"
+# tags               = {}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,10 +1,14 @@
+# ---------------------------------------------------------
+# General
+# ---------------------------------------------------------
+
 variable "subscription_id" {
   description = "Azure subscription ID"
   type        = string
 }
 
-variable "resource_group_name" {
-  description = "Name for the Azure resource group (leave empty to auto-generate from your Azure identity)"
+variable "deployer" {
+  description = "Override for deployer identifier (auto-resolved from Azure AD if empty). Required for service principal or managed identity authentication."
   type        = string
   default     = ""
 }
@@ -14,6 +18,22 @@ variable "location" {
   type        = string
   default     = "eastus2"
 }
+
+variable "environment" {
+  description = "Environment label used in resource group naming and tags"
+  type        = string
+  default     = "lab"
+}
+
+variable "tags" {
+  description = "Additional tags merged with standard tags (component, environment, deployer, managed_by)"
+  type        = map(string)
+  default     = {}
+}
+
+# ---------------------------------------------------------
+# Compute
+# ---------------------------------------------------------
 
 variable "vm_size" {
   description = "Azure VM size — F-series compute-optimized recommended (F4s_v2 for lab, F16s_v2 for load testing, F32s_v2 for production)"
@@ -33,6 +53,16 @@ variable "ssh_public_key_path" {
   default     = "~/.ssh/id_ed25519.pub"
 }
 
+variable "disk_size_gb" {
+  description = "OS disk size in GB"
+  type        = number
+  default     = 30
+}
+
+# ---------------------------------------------------------
+# Component-Specific
+# ---------------------------------------------------------
+
 variable "origin_server" {
   description = "Origin server URL that the CDN edge forwards cache misses to (e.g., https://72.19.3.185 for F5 XC, or http://origin-ip for direct)"
   type        = string
@@ -41,10 +71,4 @@ variable "origin_server" {
 variable "origin_host" {
   description = "Origin server host:port for NGINX upstream (no scheme). Use IP:443 for HTTPS or IP:80 for HTTP."
   type        = string
-}
-
-variable "environment_tag" {
-  description = "Environment tag applied to all resources"
-  type        = string
-  default     = "lab"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -64,7 +64,7 @@ variable "disk_size_gb" {
 # ---------------------------------------------------------
 
 variable "origin_server" {
-  description = "Origin server URL that the CDN edge forwards cache misses to (e.g., https://72.19.3.185 for F5 XC, or http://origin-ip for direct)"
+  description = "Origin server URL for cache miss forwarding (e.g., an HTTPS VIP or a direct HTTP origin IP)"
   type        = string
 }
 

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/terraform/vm.tf
+++ b/terraform/vm.tf
@@ -1,7 +1,7 @@
-resource "azurerm_linux_virtual_machine" "edge" {
-  name                = "vm-cdn-edge"
-  resource_group_name = azurerm_resource_group.cdn.name
-  location            = azurerm_resource_group.cdn.location
+resource "azurerm_linux_virtual_machine" "main" {
+  name                = local.name.virtual_machine
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
   size                = var.vm_size
 
   admin_username                  = var.admin_username
@@ -9,15 +9,15 @@ resource "azurerm_linux_virtual_machine" "edge" {
 
   admin_ssh_key {
     username   = var.admin_username
-    public_key = file(var.ssh_public_key_path)
+    public_key = file(pathexpand(var.ssh_public_key_path))
   }
 
-  network_interface_ids = [azurerm_network_interface.edge.id]
+  network_interface_ids = [azurerm_network_interface.main.id]
 
   os_disk {
     caching              = "ReadWrite"
     storage_account_type = "Premium_LRS"
-    disk_size_gb         = 30
+    disk_size_gb         = var.disk_size_gb
   }
 
   source_image_reference {
@@ -34,5 +34,5 @@ resource "azurerm_linux_virtual_machine" "edge" {
 
   boot_diagnostics {}
 
-  tags = azurerm_resource_group.cdn.tags
+  tags = azurerm_resource_group.main.tags
 }


### PR DESCRIPTION
## Summary

Closes #63

- Split `main.tf` into `versions.tf`, `providers.tf`, `data.tf`, `locals.tf` (resource group stays in `main.tf`)
- Add `azuread` provider for automatic deployer name resolution from Azure AD (4-tier fallback: explicit override → given_name/surname → mail prefix → object ID hash)
- Adopt Azure CAF naming convention (`rg-cdn-simulator-lab-rmordasiewicz`, `vm-cdn-simulator-rmordasiewicz`, etc.)
- Rename all HCL resource labels from `cdn`/`edge` to `main`
- Add new variables: `deployer`, `environment`, `disk_size_gb`, `tags`; remove `resource_group_name`; rename `environment_tag` → `environment`
- Expand outputs from 5 to 17 (15 standard + 2 component-specific)
- Add `pathexpand()` for SSH key path
- Upgrade `component-manifest.json` to schema v2 with structured inputs/outputs, NSG rules, health check, VM image metadata
- Standardize `docs/llms-config.json` custom sets (Deployment + CDN Configuration)
- Add `.terraform-docs.yml` and auto-generated Terraform Reference section in README
- Add `terraform_fmt`, `terraform_validate`, `terraform_docs` pre-commit hooks

## Test plan

- [x] `terraform fmt -check` passes
- [x] `terraform validate` passes
- [x] `terraform plan` succeeds with live Azure AD credentials
- [x] Deployer resolves to `rmordasiewicz` from mail prefix (R.Mordasiewicz@F5.com)
- [x] Resource group name: `rg-cdn-simulator-lab-rmordasiewicz`
- [x] All 17 outputs present in plan
- [x] Tags include all 4 standard keys (component, environment, deployer, managed_by)
- [x] Deployer override (`-var="deployer=testuser"`) produces `rg-cdn-simulator-lab-testuser`
- [x] `component-manifest.json` validates as schema v2 with 15 standard outputs
- [x] All pre-commit hooks pass