### PR TITLE
fix(test): remove set -e, fix CDN response header check URL

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -uo pipefail
 
 # CDN Simulator Post-Boot Smoke Test Suite
 # Deterministic validation of all components after deployment or reboot.
@@ -95,7 +95,7 @@ check_contains "health-vendor-azure-front-door" '"azure-front-door"' "$HEALTH"
 
 echo "── Response Headers ──"
 
-HEADERS=$(curl -sf --max-time 10 -I "${BASE}/health" 2>/dev/null || echo "")
+HEADERS=$(curl -s --max-time 10 -I "${BASE}/" 2>/dev/null || echo "")
 
 check_contains "header-x-cache-status" "X-Cache-Status" "$HEADERS"
 check_contains "header-x-cdn-edge" "X-CDN-Edge" "$HEADERS"


### PR DESCRIPTION
## Summary
- Remove `-e` from `set -euo pipefail` — `grep -q` returning non-zero triggered early exit inside `check_contains`, aborting the test suite
- Fix response header checks to use `${BASE}/` (proxied through CDN) instead of `${BASE}/health` (static endpoint that bypasses CDN proxy headers)

Verified: 25/25 PASS (16 HTTP + 9 SSH)

Closes #69

## Test plan
- [x] 25/25 smoke tests pass
- [ ] CI checks pass