### PR TITLE
docs: rewrite for terraform standardization, remove pricing, fix stale claims

### DIFF
--- a/docs/02-prerequisites.mdx
+++ b/docs/02-prerequisites.mdx
@@ -1,6 +1,6 @@
 ---
 title: Prerequisites
-description: Required tools (Azure CLI, Terraform >= 1.5, SSH key pair), Azure subscription permissions, and estimated monthly cost (~$106 USD for Standard_F4s_v2) for deploying the performance-optimized CDN edge node VM
+description: Required tools (Azure CLI, Terraform >= 1.5, SSH key pair), Azure subscription permissions, and Azure AD requirements for deploying the performance-optimized CDN edge node VM
 sidebar:
   order: 2
 ---
@@ -15,7 +15,7 @@ An active Azure subscription with permission to create:
 - Virtual networks and subnets
 - Network security groups
 - Public IP addresses
-- Virtual machines (Standard_B2s or equivalent)
+- Virtual machines
 
 ### Azure CLI
 
@@ -55,6 +55,10 @@ An SSH key pair for VM access:
 ssh-keygen -t ed25519 -f ~/.ssh/cdn-edge-key -N ""
 ```
 
+### Azure AD Permissions
+
+Your Azure AD account must have `User.Read` permissions. The deployer identifier (used in resource naming) is automatically derived from your Azure AD profile. For service principal or managed identity authentication, set the `deployer` Terraform variable explicitly.
+
 ## Optional
 
 ### Custom Domain
@@ -68,18 +72,3 @@ If you want real TLS certificates instead of self-signed:
 
 The URL of the F5 XC HTTP load balancer that this edge node will forward traffic to. This can be configured after deployment — the default NGINX config uses a placeholder that you update in the NGINX configuration.
 
-## Resource Estimates
-
-The default VM size is `Standard_F4s_v2` (compute-optimized). See [VM Sizing](03-deploy/#vm-sizing) for options.
-
-| Resource | SKU | Estimated Monthly Cost |
-|---|---|---|
-| Ubuntu 24.04 VM | Standard_F4s_v2 (4 vCPU, 8 GiB) | ~$97 USD |
-| Public IP | Standard, Static | ~$4 USD |
-| OS Disk | 30 GiB Premium SSD | ~$5 USD |
-| VNet + NSG | — | No additional cost |
-| **Total** | | **~$106 USD/month** |
-
-:::tip
-Use `terraform destroy` when the lab is not in use to avoid ongoing charges. See [Teardown](07-teardown/) for the procedure.
-:::

--- a/docs/03-deploy.mdx
+++ b/docs/03-deploy.mdx
@@ -16,14 +16,21 @@ cp terraform.tfvars.example terraform.tfvars
 
 ## Terraform Configuration
 
-### Provider and Variables
+### Terraform File Structure
 
-`main.tf` configures the Azure provider:
+The terraform directory contains 9 files following the Demo Resource Standard:
 
-```hcl file=./_data/main.tf
-```
+- `versions.tf` — Terraform and provider version constraints (azurerm ~> 4.0, azuread ~> 3.0)
+- `providers.tf` — Azure RM and Azure AD provider configuration
+- `data.tf` — Azure AD data sources for deployer auto-resolution
+- `locals.tf` — Deployer resolution, Azure Cloud Adoption Framework resource naming, standard tags
+- `main.tf` — Resource group (named `rg-cdn-simulator-{environment}-{deployer}`)
+- `variables.tf` — All input variables (3 required, 8 optional)
+- `network.tf` — VNet (10.100.0.0/16), subnet, public IP, NSG (ports 22/80/443), NIC
+- `vm.tf` — Ubuntu 24.04 VM with cloud-init via templatefile()
+- `outputs.tf` — 17 outputs (15 standard + 2 component-specific)
 
-`variables.tf` defines all configurable parameters. The `vm_size` default is `Standard_F4s_v2` (4 vCPU, 8 GiB) — see [VM Sizing](#vm-sizing) for scaling guidance:
+`variables.tf` defines 11 input variables organized into General, Compute, and Component-Specific sections. The `deployer` identifier is auto-resolved from your Azure AD account — you only need to set `subscription_id`, `origin_server`, and `origin_host`:
 
 ```hcl file=./_data/variables.tf
 ```
@@ -37,23 +44,23 @@ cp terraform.tfvars.example terraform.tfvars
 
 ### Virtual Machine with Cloud-Init
 
-`vm.tf` creates the Ubuntu 24.04 VM and passes the cloud-init template with origin server variables:
+`vm.tf` creates the Ubuntu 24.04 VM. The SSH public key path is expanded via `pathexpand()` to handle `~`. Cloud-init template receives `origin_server` and `origin_host` variables:
 
 ```hcl file=./_data/vm.tf
 ```
 
 ### Cloud-Init Provisioning
 
-`cloud-init.yaml` is the production-optimized configuration verified under 48 hours of continuous load testing at 350K req/s peak. It provisions kernel tuning, systemd limits, NGINX with performance-optimized buffers, 128 MB cache keys zone, upstream keepalive pool, gzip compression, and 67+ CDN vendor headers from Akamai, Cloudflare, CloudFront, Fastly, and Azure Front Door. See [NGINX Configuration](../04-nginx-config/) for the complete tuning reference.
+`cloud-init.yaml` provisions the VM with kernel tuning, systemd limits, NGINX with performance-optimized configuration, 128 MB cache keys zone, upstream keepalive pool, gzip compression, and 67+ CDN vendor headers. A shared helper library (`/usr/local/lib/cloud-init-helpers.sh`) provides retry logic and progress logging to `/var/log/cloud-init-progress.log`.
 
-The cloud-init uses Terraform template variables: `${origin_host}` for the upstream server address. NGINX variables like `${request_id}` must be escaped as `$${request_id}` in the Terraform templatefile.
+The cloud-init uses Terraform template variables: `${origin_server}` and `${origin_host}` for the upstream configuration. NGINX variables like `${request_id}` are escaped as `$${request_id}` in the Terraform templatefile.
 
 ```yaml file=./_data/cloud-init.yaml
 ```
 
 ### Outputs
 
-`outputs.tf` exposes the public IP, SSH command, edge URL, and health check endpoint:
+`outputs.tf` exposes 17 outputs following the Demo Resource Standard — 15 standard outputs shared by all demo resources (`deployer`, `public_ip`, `private_ip`, `ssh_command`, `resource_group_name`, `vm_name`, `nsg_name`, `vnet_name`, `subnet_id`, `component`, `environment`, `resource_group_id`, `vm_id`, `nsg_id`, `location`) plus 2 component-specific outputs (`edge_url`, `health_check_url`):
 
 ```hcl file=./_data/outputs.tf
 ```
@@ -82,18 +89,7 @@ Terraform outputs the public IP, SSH command, and edge URL after successful depl
 
 ## VM Sizing
 
-The F-series compute-optimized VMs are recommended for this CPU-bound NGINX proxy workload. The cloud-init kernel tuning and NGINX config scale automatically with vCPU count (`worker_processes auto`).
-
-| VM SKU | vCPU | RAM | Network | Use Case | Est. Monthly |
-|---|---|---|---|---|---|
-| Standard_F4s_v2 | 4 | 8 GiB | 10 Gbps | Lab/demo | ~$97 |
-| Standard_F8s_v2 | 8 | 16 GiB | 12.5 Gbps | Load testing | ~$194 |
-| Standard_F16s_v2 | 16 | 32 GiB | 12.5 Gbps | Heavy load testing | ~$389 |
-| Standard_F32s_v2 | 32 | 64 GiB | 16 Gbps | Production/benchmarking | ~$778 |
-
-:::tip
-Use `terraform destroy` when the lab is not in use to avoid ongoing charges. See [Teardown](../07-teardown/) for the procedure.
-:::
+The F-series compute-optimized VMs are recommended for this CPU-bound NGINX proxy workload. The default `Standard_F4s_v2` (4 vCPU, 8 GiB) is suitable for lab and demo use. Override the `vm_size` variable for load testing or production benchmarking scenarios. Cloud-init kernel tuning and NGINX config scale automatically with vCPU count (`worker_processes auto`).
 
 ## Post-Deploy
 
@@ -109,7 +105,14 @@ Expected response:
 {
   "status": "healthy",
   "component": "cdn-edge",
-  "engine": "nginx"
+  "engine": "nginx",
+  "vendor_profiles": [
+    "akamai",
+    "cloudflare",
+    "cloudfront",
+    "fastly",
+    "azure-front-door"
+  ]
 }
 ```
 

--- a/docs/05-verify.mdx
+++ b/docs/05-verify.mdx
@@ -21,7 +21,14 @@ Expected output:
 {
   "status": "healthy",
   "component": "cdn-edge",
-  "engine": "nginx"
+  "engine": "nginx",
+  "vendor_profiles": [
+    "akamai",
+    "cloudflare",
+    "cloudfront",
+    "fastly",
+    "azure-front-door"
+  ]
 }
 ```
 
@@ -112,6 +119,22 @@ If this fails, check:
 1. The `origin_server` variable is correct in the Terraform config
 2. The origin server allows inbound connections from the edge node's public IP
 3. DNS resolution works from the VM (`nslookup your-origin.example.com`)
+
+## Cloud-Init Progress
+
+Monitor provisioning progress via the cloud-init log:
+
+```bash
+ssh azureuser@<PUBLIC_IP> "tail -f /var/log/cloud-init-progress.log"
+```
+
+Expected phases: `[init]`, `[nic]` (dynamic NIC detection), `[complete]`.
+
+If cloud-init reports errors:
+
+```bash
+ssh azureuser@<PUBLIC_IP> "sudo cloud-init status --long"
+```
 
 ## End-to-End Test
 
@@ -213,5 +236,5 @@ sudo tail -f /var/log/cloud-init-output.log
 
 ### Connection refused on port 80/443
 
-- Verify the NSG rules are applied: `az network nsg rule list --nsg-name nsg-cdn-edge --resource-group rg-cdn-simulator -o table`
+- Verify the NSG rules are applied: `az network nsg rule list --nsg-name "$(terraform output -raw nsg_name)" --resource-group "$(terraform output -raw resource_group_name)" -o table`
 - Verify NGINX is listening: `ssh azureuser@<PUBLIC_IP> "sudo ss -tlnp | grep nginx"`

--- a/docs/07-teardown.mdx
+++ b/docs/07-teardown.mdx
@@ -1,6 +1,6 @@
 ---
 title: Teardown
-description: Run terraform destroy to remove all Azure resources (resource group, VM, VNet, PIP, NSG), clean up local Terraform state, and revert DNS or hosts file changes. Monthly cost stops immediately on destroy.
+description: Run terraform destroy to remove all Azure resources (resource group, VM, VNet, PIP, NSG), clean up local Terraform state, and revert DNS or hosts file changes.
 sidebar:
   order: 7
 ---
@@ -27,12 +27,10 @@ Confirm all resources have been removed:
 
 ```bash
 # Check resource group is gone
-az group show --name rg-cdn-simulator 2>&1 | grep -q "ResourceGroupNotFound" \
+az group show --name "$(terraform output -raw resource_group_name)" 2>&1 \
+  | grep -q "ResourceGroupNotFound" \
   && echo "Resource group deleted" \
   || echo "Resource group still exists"
-
-# List any remaining resources (should return empty)
-az resource list --resource-group rg-cdn-simulator -o table 2>/dev/null
 ```
 
 ## Clean Up Local State
@@ -54,6 +52,3 @@ sudo sed -i '/<CDN_EDGE_PUBLIC_IP>/d' /etc/hosts
 
 If you created a DNS A record, delete it through your DNS provider.
 
-## Cost Reference
-
-While running, the CDN edge node costs approximately $39 USD/month. After `terraform destroy`, all charges stop. There are no residual costs from deleted resources.


### PR DESCRIPTION
## Summary

- Rewrites deployment, prerequisites, verification, and teardown docs to reflect the Terraform-standardized workflow
- Removes outdated Azure pricing estimates and stale architecture claims
- Fixes codespell error: spells out "Azure Cloud Adoption Framework" instead of abbreviation "CAF"

Closes #73

## Test plan

- [ ] CI checks pass (super-linter, linked-issue check, codespell)
- [ ] Docs render correctly on GitHub Pages after merge