### PR TITLE
docs: add component name and dependency context to deployment custom set description

### DIFF
--- a/docs/llms-config.json
+++ b/docs/llms-config.json
@@ -2,7 +2,7 @@
   "customSets": [
     {
       "label": "Deployment",
-      "description": "Terraform IaC deployment with prerequisites and teardown",
+      "description": "CDN Simulator Terraform deployment — requires subscription_id, origin_server, and origin_host from a deployed origin server",
       "paths": ["02-prerequisites*", "03-deploy*", "07-teardown*"]
     },
     {


### PR DESCRIPTION
## Summary

- Update the Deployment customSet description in `docs/llms-config.json` to include the component name ("CDN Simulator") and explicit dependency on origin-server outputs (`subscription_id`, `origin_server`, `origin_host`)
- The starlight-llms-txt plugin uses this description as the SYSTEM tag header in `deployment.txt`, so specificity is critical for AI assistants navigating multi-component documentation

Closes #79

## Test plan

- [ ] CI checks pass
- [ ] Verify `docs/llms-config.json` is valid JSON after the change
- [ ] Confirm the updated description accurately reflects the deployment dependencies