### PR TITLE
docs: add output-wiring section to deploy guide

### DIFF
--- a/docs/03-deploy.mdx
+++ b/docs/03-deploy.mdx
@@ -116,4 +116,25 @@ Expected response:
 }
 ```
 
+## Wiring from Upstream Components
+
+The CDN simulator requires a deployed origin server. Use the origin server's terraform outputs to populate the required variables:
+
+```bash
+cd ../origin-server/terraform
+origin_ip=$(terraform output -raw public_ip)
+
+cd ../../cdn-simulator/terraform
+cat > terraform.tfvars <<EOF
+subscription_id = "your-subscription-id"
+origin_server   = "http://${origin_ip}"
+origin_host     = "${origin_ip}:80"
+EOF
+```
+
+| Required Variable | Source | Format |
+|---|---|---|
+| `origin_server` | Origin server `public_ip` output | `http://<ip>` (include scheme) |
+| `origin_host` | Origin server `public_ip` output | `<ip>:80` (no scheme, include port) |
+
 Proceed to [NGINX Configuration](../04-nginx-config/) for customization options or [Verify](../05-verify/) for cache testing.


### PR DESCRIPTION
## Summary

- Add "Wiring from Upstream Components" section to `docs/03-deploy.mdx`
- Include a table documenting the exact source and format for `origin_server` (`http://<ip>`) and `origin_host` (`<ip>:80`)
- Add bash snippet showing how to pull values from origin-server terraform outputs

Closes #81

## Test plan

- [ ] CI checks pass
- [ ] Docs site builds and renders the new section correctly
- [ ] Variable format table is accurate against terraform variable definitions